### PR TITLE
Script/read ado organization advanced security status

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,8 @@
 node_modules/
 package-lock.json
 package.json
+powershell/deploy.ps1
+references/deploy.ps1
 
 ### VisualStudioCode ###
 .vscode/*

--- a/powershell/functions/Read-AdoOrganizationAdvancedSecurityStatus.ps1
+++ b/powershell/functions/Read-AdoOrganizationAdvancedSecurityStatus.ps1
@@ -3,8 +3,14 @@
     Determines whether Advanced Security is enabled for an Azure DevOps organization.
 
 .DESCRIPTION
-    This function queries the Azure DevOps Advanced Security API and detects whether the feature is enabled,
-    not yet enabled, or enabled but usage data is not available yet.
+    This function queries the Azure DevOps Advanced Security API and detects whether Advanced Security
+    is enabled for the organization. It handles three scenarios:
+    - Advanced Security is enabled and usage data is returned
+    - Advanced Security is enabled but usage data is not yet available
+    - Advanced Security is not enabled at all
+
+    If enabled and reporting, the function outputs billing date, unique committer count,
+    and billed user identities.
 
 .PARAMETER Organization
     The name of your Azure DevOps organization (e.g. 'devjevnl').
@@ -25,11 +31,11 @@
     https://advsec.dev.azure.com/{org}/_apis/Management/MeterUsage/Last
 
     Response types handled:
-    - AdvSecNotEnabledForOrgException → Not enabled
-    - MeterUsageNotFoundException     → Enabled, no usage yet
-    - 200 OK with data                → Enabled and reporting
+    - 200 OK with usage data             → Advanced Security is enabled
+    - MeterUsageNotFoundException       → Enabled but usage data is not yet available
+    - AdvSecNotEnabledForOrgException   → Not enabled
 
-    Version     : 0.5.1
+    Version     : 0.6.0
     Author      : Jev - @devjevnl | https://www.devjev.nl
     Source      : https://github.com/thecloudexplorers/simply-scripted
 
@@ -58,19 +64,32 @@ function Read-AdoOrganizationAdvancedSecurityStatus {
     try {
         $rawResponse = Invoke-WebRequest -Uri $uri -Method Get -Headers $headers -UseBasicParsing
 
-        # Token failure fallback
         if ($rawResponse.Content -match '<html' -or $rawResponse.RawContent -match 'Sign In') {
             throw "Access denied or token expired. Please verify your Bearer token is still valid."
         }
 
-        # Try parsing as JSON
         $response = $rawResponse.Content | ConvertFrom-Json
 
         Write-Host ""
         Write-Host "===== Azure DevOps Advanced Security Status ====="
         Write-Host ""
-        Write-Host "Advanced Security is ENABLED for organization: $Organization"
-        Write-Host "Usage data is available."
+
+        if ($response.isAdvSecEnabled -eq $true) {
+            Write-Host "Advanced Security is ENABLED for organization: $Organization"
+            Write-Host "Billing Date             : $($response.billingDate)"
+            Write-Host "Billable Status          : $($response.isAdvSecBillable)"
+            Write-Host "Unique Committer Count   : $($response.uniqueCommitterCount)"
+
+            if ($response.billedUsers) {
+                Write-Host "Billed Users:"
+                foreach ($user in $response.billedUsers) {
+                    Write-Host "  - $($user.userIdentity.displayName)"
+                }
+            }
+        } else {
+            Write-Host "Advanced Security is NOT enabled for organization: $Organization"
+        }
+
         Write-Host ""
         Write-Host "Assessment complete."
     } catch {
@@ -86,7 +105,6 @@ function Read-AdoOrganizationAdvancedSecurityStatus {
             Write-Host "Advanced Security is ENABLED but usage data is not yet available for organization: $Organization"
         } else {
             Write-Error "Unexpected error occurred: $($_.Exception.Message)"
-            return
         }
 
         Write-Host ""

--- a/powershell/functions/Read-AdoOrganizationAdvancedSecurityStatus.ps1
+++ b/powershell/functions/Read-AdoOrganizationAdvancedSecurityStatus.ps1
@@ -1,0 +1,95 @@
+<#
+.SYNOPSIS
+    Determines whether Advanced Security is enabled for an Azure DevOps organization.
+
+.DESCRIPTION
+    This function queries the Azure DevOps Advanced Security API and detects whether the feature is enabled,
+    not yet enabled, or enabled but usage data is not available yet.
+
+.PARAMETER Organization
+    The name of your Azure DevOps organization (e.g. 'devjevnl').
+
+.PARAMETER AccessToken
+    A valid Azure DevOps Bearer token with access to organization settings.
+
+.EXAMPLE
+    $advSecParams = @{
+        Organization = "devjevnl"
+        AccessToken  = $token
+    }
+
+    Read-AdoOrganizationAdvancedSecurityStatus @advSecParams
+
+.NOTES
+    This function uses the internal Azure DevOps endpoint:
+    https://advsec.dev.azure.com/{org}/_apis/Management/MeterUsage/Last
+
+    Response types handled:
+    - AdvSecNotEnabledForOrgException → Not enabled
+    - MeterUsageNotFoundException     → Enabled, no usage yet
+    - 200 OK with data                → Enabled and reporting
+
+    Version     : 0.5.1
+    Author      : Jev - @devjevnl | https://www.devjev.nl
+    Source      : https://github.com/thecloudexplorers/simply-scripted
+
+.LINK
+    https://learn.microsoft.com/en-us/azure/devops/organizations/security/advanced-security-overview
+#>
+function Read-AdoOrganizationAdvancedSecurityStatus {
+    [CmdletBinding()]
+    param (
+        # Azure DevOps organization name
+        [Parameter(Mandatory)]
+        [string]$Organization,
+
+        # Valid Bearer token
+        [Parameter(Mandatory)]
+        [string]$AccessToken
+    )
+
+    $uri = "https://advsec.dev.azure.com/$Organization/_apis/Management/MeterUsage/Last?api-version=7.1-preview.1"
+
+    $headers = @{
+        Authorization = "Bearer $AccessToken"
+        Accept        = "application/json"
+    }
+
+    try {
+        $rawResponse = Invoke-WebRequest -Uri $uri -Method Get -Headers $headers -UseBasicParsing
+
+        # Token failure fallback
+        if ($rawResponse.Content -match '<html' -or $rawResponse.RawContent -match 'Sign In') {
+            throw "Access denied or token expired. Please verify your Bearer token is still valid."
+        }
+
+        # Try parsing as JSON
+        $response = $rawResponse.Content | ConvertFrom-Json
+
+        Write-Host ""
+        Write-Host "===== Azure DevOps Advanced Security Status ====="
+        Write-Host ""
+        Write-Host "Advanced Security is ENABLED for organization: $Organization"
+        Write-Host "Usage data is available."
+        Write-Host ""
+        Write-Host "Assessment complete."
+    } catch {
+        $message = $_.ErrorDetails.Message
+
+        Write-Host ""
+        Write-Host "===== Azure DevOps Advanced Security Status ====="
+        Write-Host ""
+
+        if ($message -match 'AdvSecNotEnabledForOrgException') {
+            Write-Host "Advanced Security is NOT enabled for organization: $Organization"
+        } elseif ($message -match 'MeterUsageNotFoundException') {
+            Write-Host "Advanced Security is ENABLED but usage data is not yet available for organization: $Organization"
+        } else {
+            Write-Error "Unexpected error occurred: $($_.Exception.Message)"
+            return
+        }
+
+        Write-Host ""
+        Write-Host "Assessment complete."
+    }
+}

--- a/powershell/functions/Read-AdoOrganizationAdvancedSecurityStatus.ps1
+++ b/powershell/functions/Read-AdoOrganizationAdvancedSecurityStatus.ps1
@@ -31,7 +31,7 @@
     https://advsec.dev.azure.com/{org}/_apis/Management/MeterUsage/Last
 
     Response types handled:
-    - 200 OK with usage data             → Advanced Security is enabled
+    - 200 OK with usage data            → Advanced Security is enabled
     - MeterUsageNotFoundException       → Enabled but usage data is not yet available
     - AdvSecNotEnabledForOrgException   → Not enabled
 
@@ -49,20 +49,15 @@ function Read-AdoOrganizationAdvancedSecurityStatus {
         [Parameter(Mandatory)]
         [string]$Organization,
 
-        # Valid Bearer token
         [Parameter(Mandatory)]
-        [string]$AccessToken
+        [ValidateNotNullOrEmpty()]
+        [System.Collections.Hashtable] $AdoAuthenticationHeader
     )
 
-    $uri = "https://advsec.dev.azure.com/$Organization/_apis/Management/MeterUsage/Last?api-version=7.1-preview.1"
-
-    $headers = @{
-        Authorization = "Bearer $AccessToken"
-        Accept        = "application/json"
-    }
+    $meterUsageUri = "https://advsec.dev.azure.com/$Organization/_apis/Management/MeterUsage/Last?api-version=7.1-preview.1"
 
     try {
-        $rawResponse = Invoke-WebRequest -Uri $uri -Method Get -Headers $headers -UseBasicParsing
+        $rawResponse = Invoke-WebRequest -Uri $meterUsageUri -Method Get -Headers $AdoAuthenticationHeader -UseBasicParsing
 
         if ($rawResponse.Content -match '<html' -or $rawResponse.RawContent -match 'Sign In') {
             throw "Access denied or token expired. Please verify your Bearer token is still valid."

--- a/references/Read-AdoOrganizationAdvancedSecurityUsage.ps1
+++ b/references/Read-AdoOrganizationAdvancedSecurityUsage.ps1
@@ -1,0 +1,139 @@
+<#
+.SYNOPSIS
+    Determines whether Advanced Security is enabled for an Azure DevOps
+    organization.
+
+.DESCRIPTION
+    This function queries the Azure DevOps Advanced Security API and detects
+    whether Advanced Security is enabled for the organization. It handles three
+    scenarios:
+    - Advanced Security is enabled and usage data is returned
+    - Advanced Security is enabled but usage data is not yet available
+    - Advanced Security is not enabled at all
+
+    If enabled and reporting, the function outputs billing date, billable
+    status, and billed user identities. The function also checks for token
+    expiration and access errors.
+
+.PARAMETER Organization
+    The name of your Azure DevOps organization (e.g. 'devjevnl').
+
+.PARAMETER AdoAuthenticationHeader
+    A hashtable containing the Azure DevOps authentication headers for PAT
+    usage. Should include 'Content-Type' and 'Authorization' keys, e.g.:
+    Example:
+        $patAuthenticationHeader = @{
+            'Content-Type'  = 'application/json'
+            'Authorization' = 'Basic ' + $adoAuthToken
+        }
+
+.EXAMPLE
+    $adoAuthTokenParams = @{
+        PatToken         = $patTokenReadAdvancedSecurity
+        PatTokenOwnerName = $PatTokenOwnerName
+    }
+    $adoAuthToken = New-AdoAuthenticationToken @adoAuthTokenParams
+
+    $patAuthenticationHeader = @{
+        'Content-Type'  = 'application/json'
+        'Authorization' = 'Basic ' + $adoAuthToken
+    }
+    $params = @{
+        Organization           = "devjevnl"
+        AdoAuthenticationHeader = $patAuthenticationHeader
+    }
+    Read-AdoOrganizationAdvancedSecurityStatus @params
+
+    Read-AdoOrganizationAdvancedSecurityStatus @advSecParams
+
+.NOTES
+    This function uses the internal Azure DevOps endpoint:
+    https://advsec.dev.azure.com/{org}/_apis/Management/MeterUsage/Last
+
+    Response types handled:
+    - 200 OK with usage data       -> Advanced Security is enabled
+    - MeterUsageNotFoundException  -> Not enabled or data usage not available
+    - HTML/Sign In response        -> Token expired or access denied
+
+    Version     : 1.0.0
+    Author      : Jev - @devjevnl | https://www.devjev.nl
+    Source      : https://github.com/thecloudexplorers/simply-scripted
+
+.LINK
+    https://learn.microsoft.com/en-us/azure/devops/repos/security/configure-github-advanced-security-features?view=azure-devops&tabs=yaml&pivots=standalone-ghazdo&wt.mc_id=DT-MVP-5005327
+#>
+function Read-AdoOrganizationAdvancedSecurityUsage {
+    [CmdletBinding()]
+    param (
+        # Azure DevOps organization name
+        [Parameter(Mandatory)]
+        [string]$Organization,
+
+        [Parameter(Mandatory)]
+        [ValidateNotNullOrEmpty()]
+        [System.Collections.Hashtable] $AdoAuthenticationHeader
+    )
+
+    $meterUsageUri = "https://advsec.dev.azure.com/$Organization/_apis/Management/MeterUsage/Last?api-version=7.1-preview.1"
+
+    $enablementUri = "https://advsec.dev.azure.com/$Organization/_apis/management/enablement?api-version=7.2-preview.3"
+
+    try {
+        # Call the Advanced Security Meter Usage API
+        # Using Invoke-RestMethod to directly parse JSON response
+        $invokeParams = @{
+            Uri             = $enablementUri
+            Method          = 'GET'
+            Headers         = $AdoAuthenticationHeader
+            UseBasicParsing = $true
+        }
+        $restResponse = Invoke-RestMethod @invokeParams
+    } catch {
+        $jsonErrorMessage = $_.ErrorDetails.Message | ConvertFrom-Json -ErrorAction SilentlyContinue
+
+        if ($null -ne $jsonErrorMessage) {
+            <#
+            Ensure that only the MeterUsageNotFoundException is ignored as this
+            is expected when Advanced Security is not enabled
+            #>
+            if ($jsonErrorMessage.typeKey -ne "MeterUsageNotFoundException") {
+                Write-Error "Unexpected error occurred: $($_.Exception.Message)" -ErrorAction Stop
+            }
+        } else {
+            Write-Error "Unexpected error occurred: $($_.Exception.Message)" -ErrorAction Stop
+        }
+    }
+
+    $responseHashTable = @{
+        isAdvSecEnabled  = $false
+        billingDate      = $null
+        isAdvSecBillable = $false
+        billedUsers      = @()
+    }
+
+    # Check if response content returns a html page which usually indicates token expired
+    if ($rawResponse.Content -match '<html' -or $rawResponse.RawContent -match 'Sign In') {
+        Write-Error "Access denied or token expired. Please verify your Bearer token is still valid." -ErrorAction Stop
+
+    } elseif ($null -ne $restResponse) {
+        # Advanced Security is enabled, check if usage data is available
+        if ($restResponse.isAdvSecEnabled -eq $true) {
+
+            Write-Information -Message "Advanced Security is ENABLED for organization [$Organization]"
+
+            # populate output hash table
+            $responseHashTable.isAdvSecEnabled = $restResponse.isAdvSecEnabled
+            $responseHashTable.billingDate = $restResponse.billingDate
+            $responseHashTable.isAdvSecBillable = $restResponse.isAdvSecBillable
+            $responseHashTable.billedUsers = $restResponse.billedUsers
+
+            Write-Output $responseHashTable
+        } else {
+            Write-Information -Message "Advanced Security is NOT enabled for organization [$Organization]"
+        }
+    } else {
+        Write-Information -Message "Advanced Security is NOT enabled for organization [$Organization]"
+    }
+
+    return $responseHashTable
+}


### PR DESCRIPTION
# Add Advanced Security Organization Status Script

## Summary

This PR introduces a new PowerShell script, `Read-AdoOrganizationAdvancedSecurityStatus.ps1`, which enables users to query and report on organization-level Advanced Security enablement settings in Azure DevOps.

## Motivation

This script provides a simple, reusable way to programmatically check the status of Advanced Security features at the organization level, supporting compliance, automation, and reporting needs for Azure DevOps environments.

Because the function is self-contained and returns clear, structured output, it is easily pluggable into any compliance or drift detection solution for Azure DevOps. This enables (platform) teams to automate the monitoring of security plan enablement, quickly detect configuration changes, and ensure organizational policies are consistently enforced across all environments.

## Features

- **Organization-Level Security Status:**  
  Checks whether Secret Protection and Code Security plans are enabled for a specified Azure DevOps organization.

- **Modern API Usage:**  
  Utilizes the latest Azure DevOps Advanced Security enablement endpoint:  
  `https://advsec.dev.azure.com/{organization}/_apis/management/enablement?api-version=7.2-preview.3`

- **Robust Output:**  
  Returns a hashtable with:
  - `isSecretProtectionPlanEnabled` (boolean)
  - `isCodeSecurityPlanEnabled` (boolean)

- **PAT Authentication:**  
  Accepts a hashtable for authentication headers, supporting Personal Access Token (PAT) via Basic Authorization.

- **Comprehensive Help & Examples:**  
  Includes detailed comment-based help, parameter documentation, and example usage for easy integration.

- **Error Handling:**  
  Handles null/empty responses, token expiration, and access errors gracefully.

