### PR TITLE
Add Read-AdoRepoAdvancedSecurityStatus.ps1: Organization-wide Repo Security Status Script

### DIFF
--- a/powershell/functions/Read-AdoRepoAdvancedSecurityStatus.ps1
+++ b/powershell/functions/Read-AdoRepoAdvancedSecurityStatus.ps1
@@ -1,0 +1,115 @@
+function Read-AdoRepoAdvancedSecurityStatus {
+    [CmdletBinding()]
+    param (
+        [Parameter(Mandatory)]
+        [string]$Organization,
+
+        [Parameter(Mandatory)]
+        [ValidateNotNullOrEmpty()]
+        [System.Collections.Hashtable] $AdoAuthenticationHeader
+    )
+
+    # Get the current status of Advanced Security for the organization
+    # https://learn.microsoft.com/en-us/rest/api/azure/devops/advancedsecurity/org-enablement/get?view=azure-devops-rest-7.2&wt.mc_id=DT-MVP-5005327
+    # GET https://advsec.dev.azure.com/{organization}/_apis/management/enablement?api-version=7.2-preview.3
+    $enablementUri = "https://advsec.dev.azure.com/$Organization/_apis/management/enablement?api-version=7.2-preview.3"
+
+    try {
+
+        # Call the Advanced Security Enablement API
+        $invokeParams = @{
+            Uri             = $enablementUri
+            Method          = 'GET'
+            Headers         = $AdoAuthenticationHeader
+            UseBasicParsing = $true
+        }
+        $restResponse = Invoke-RestMethod @invokeParams
+
+        # Check if response content returns a html page which usually indicates token expired
+        if ($restResponse.Content -match '<html' -or $restResponse.RawContent -match 'Sign In') {
+            Write-Error "Access denied or token expired. Please verify your Bearer token is still valid." -ErrorAction Stop
+
+        } else {
+            [System.Object[]]$secretProtectionEnabledRepos = $restResponse.reposEnablementStatus |
+            Where-Object { $_.secretProtectionFeatures.secretProtectionEnabled -eq $true }
+
+            # Initialize result collection
+            $result = [System.Collections.ArrayList]::new()
+
+            # Process Secret Protection enabled repositories
+            foreach ($currentRepo in $secretProtectionEnabledRepos) {
+                $projectId = $currentRepo.projectId
+                $repoId = $currentRepo.repositoryId
+
+                # Get project details
+                $projectUriTemplate = "https://dev.azure.com/{0}/_apis/projects/{1}?api-version=7.0"
+                $projectUri = $projectUriTemplate -f $Organization, $projectId
+                $projectInfo = Invoke-RestMethod -Uri $projectUri -Headers $AdoAuthenticationHeader -Method Get
+
+                # Get repository details
+                $repoUriTemplate = "https://dev.azure.com/{0}/{1}/_apis/git/repositories/{2}?api-version=7.0"
+                $repoUri = $repoUriTemplate -f $Organization, $projectId, $repoId
+
+                $repoInfo = Invoke-RestMethod -Uri $repoUri -Headers $AdoAuthenticationHeader -Method Get
+
+                # Add to result collection
+                [System.Void]$result.Add([PSCustomObject]@{
+                        ProjectId                 = $projectId
+                        ProjectName               = $projectInfo.name
+                        RepositoryId              = $repoId
+                        RepositoryName            = $repoInfo.name
+                        SecretProtectionEnabled   = $true
+                        DependencyScanningEnabled = $false
+                        CodeSecurityEnabled       = $false
+                    })
+            }
+
+            [System.Object[]]$codeSecurityEnabledRepos = $restResponse.reposEnablementStatus |
+            Where-Object { $_.codeSecurityFeatures.codeSecurityEnabled -eq $true }
+
+            # Process Code Security enabled repositories
+            foreach ($currentRepo in $codeSecurityEnabledRepos) {
+                $projectId = $currentRepo.projectId
+                $repoId = $currentRepo.repositoryId
+
+                # Check if this repository is already in our results (has both enabled)
+                $existingRepo = $result | Where-Object { $_.RepositoryId -eq $repoId }
+
+                if ($existingRepo) {
+                    # Update existing entry
+                    $existingRepo.CodeSecurityEnabled = $currentRepo.codeSecurityFeatures.codeSecurityEnabled
+                    $existingRepo.DependencyScanningEnabled = $currentRepo.codeSecurityFeatures.dependencyScanningEnabled
+
+                } else {
+                    # Get project details
+                    $projectUriTemplate = "https://dev.azure.com/{0}/_apis/projects/{1}?api-version=7.0"
+                    $projectUri = $projectUriTemplate -f $Organization, $projectId
+                    $projectInfo = Invoke-RestMethod -Uri $projectUri -Headers $AdoAuthenticationHeader -Method Get
+
+                    # Get repository details
+                    $repoUriTemplate = "https://dev.azure.com/{0}/{1}/_apis/git/repositories/{2}?api-version=7.0"
+                    $repoUri = $repoUriTemplate -f $Organization, $projectId, $repoId
+                    $repoInfo = Invoke-RestMethod -Uri $repoUri -Headers $AdoAuthenticationHeader -Method Get
+
+                    # Add new entry
+                    [System.Void]$result.Add([PSCustomObject]@{
+                            ProjectId                 = $projectId
+                            ProjectName               = $projectInfo.name
+                            RepositoryId              = $repoId
+                            RepositoryName            = $repoInfo.name
+                            SecretProtectionEnabled   = $false
+                            CodeSecurityEnabled       = $currentRepo.codeSecurityFeatures.codeSecurityEnabled
+                            DependencyScanningEnabled = $currentRepo.codeSecurityFeatures.dependencyScanningEnabled
+                        })
+                }
+            }
+
+            # Return the result
+            $result
+
+            Write-Host "Stopped here!!!"
+        }
+    } catch {
+        Write-Error "Unexpected error occurred: $($_.Exception.Message)" -ErrorAction Stop
+    }
+}

--- a/powershell/functions/Read-AdoRepoAdvancedSecurityStatus.ps1
+++ b/powershell/functions/Read-AdoRepoAdvancedSecurityStatus.ps1
@@ -138,7 +138,8 @@ function Read-AdoRepoAdvancedSecurityStatus {
                 $secretProtectionChangedByDisplayName = $null
                 if ($currentRepo.secretProtectionFeatures.secretProtectionChangedBy -ne "00000000-0000-0000-0000-000000000000") {
                     $identityUriTemplate = "https://vssps.dev.azure.com/{0}/_apis/identities/{1}?api-version=7.2-preview.1"
-                    $identityUri = $identityUriTemplate -f $Organization, $currentRepo.secretProtectionFeatures.secretProtectionChangedBy
+                    $changedById = $currentRepo.secretProtectionFeatures.secretProtectionChangedBy
+                    $identityUri = $identityUriTemplate -f $Organization, $changedById
 
                     $identityInfo = Invoke-RestMethod -Uri $identityUri -Headers $AdoAuthenticationHeader -Method 'GET'
                     $secretProtectionChangedByDisplayName = $identityInfo.providerDisplayName

--- a/powershell/functions/Read-AdoRepoAdvancedSecurityStatus.ps1
+++ b/powershell/functions/Read-AdoRepoAdvancedSecurityStatus.ps1
@@ -53,7 +53,7 @@ function Read-AdoRepoAdvancedSecurityStatus {
                 $repoInfo = Invoke-RestMethod -Uri $repoUri -Headers $AdoAuthenticationHeader -Method Get
 
                 # Add to result collection
-                [System.Void]$result.Add([PSCustomObject]@{
+                [System.Void]$repoAdvancedSecurityStatusCollection.Add([PSCustomObject]@{
                         ProjectId                 = $projectId
                         ProjectName               = $projectInfo.name
                         RepositoryId              = $repoId
@@ -92,7 +92,7 @@ function Read-AdoRepoAdvancedSecurityStatus {
                     $repoInfo = Invoke-RestMethod -Uri $repoUri -Headers $AdoAuthenticationHeader -Method Get
 
                     # Add new entry
-                    [System.Void]$result.Add([PSCustomObject]@{
+                    [System.Void]$repoAdvancedSecurityStatusCollection.Add([PSCustomObject]@{
                             ProjectId                 = $projectId
                             ProjectName               = $projectInfo.name
                             RepositoryId              = $repoId
@@ -103,6 +103,12 @@ function Read-AdoRepoAdvancedSecurityStatus {
                         })
                 }
             }
+
+            # Summary output
+            $reposWithSecretProtection = $repoAdvancedSecurityStatusCollection | Where-Object { $_.SecretProtectionEnabled -eq $true }
+            $reposWithCodeSecurity = $repoAdvancedSecurityStatusCollection | Where-Object { $_.CodeSecurityEnabled -eq $true }
+            Write-Information -Message "Total repositories with Secret Protection enabled: [$($reposWithSecretProtection.Count)]"
+            Write-Information -Message "Total repositories with Code Security enabled: [$($reposWithCodeSecurity.Count)]"
 
             # Return the result
             return  $repoAdvancedSecurityStatusCollection

--- a/powershell/functions/Read-AdoRepoAdvancedSecurityStatus.ps1
+++ b/powershell/functions/Read-AdoRepoAdvancedSecurityStatus.ps1
@@ -12,7 +12,7 @@ function Read-AdoRepoAdvancedSecurityStatus {
     # Get the current status of Advanced Security for the organization
     # https://learn.microsoft.com/en-us/rest/api/azure/devops/advancedsecurity/org-enablement/get?view=azure-devops-rest-7.2&wt.mc_id=DT-MVP-5005327
     # GET https://advsec.dev.azure.com/{organization}/_apis/management/enablement?api-version=7.2-preview.3
-    $enablementUri = "https://advsec.dev.azure.com/$Organization/_apis/management/enablement?api-version=7.2-preview.3"
+    $enablementUri = "https://advsec.dev.azure.com/$Organization/_apis/management/enablement?includeAllProperties=true&api-version=7.2-preview.3"
 
     try {
 
@@ -30,8 +30,7 @@ function Read-AdoRepoAdvancedSecurityStatus {
             Write-Error "Access denied or token expired. Please verify your Bearer token is still valid." -ErrorAction Stop
 
         } else {
-            [System.Object[]]$secretProtectionEnabledRepos = $restResponse.reposEnablementStatus |
-            Where-Object { $_.secretProtectionFeatures.secretProtectionEnabled -eq $true }
+            [System.Collections.ArrayList]$secretProtectionEnabledRepos = $restResponse.reposEnablementStatus
 
             # Initialize result collection
             $repoAdvancedSecurityStatusCollection = [System.Collections.ArrayList]::new()
@@ -44,76 +43,66 @@ function Read-AdoRepoAdvancedSecurityStatus {
                 # Get project details
                 $projectUriTemplate = "https://dev.azure.com/{0}/_apis/projects/{1}?api-version=7.0"
                 $projectUri = $projectUriTemplate -f $Organization, $projectId
-                $projectInfo = Invoke-RestMethod -Uri $projectUri -Headers $AdoAuthenticationHeader -Method Get
+                $projectInfo = Invoke-RestMethod -Uri $projectUri -Headers $AdoAuthenticationHeader -Method 'GET'
 
                 # Get repository details
                 $repoUriTemplate = "https://dev.azure.com/{0}/{1}/_apis/git/repositories/{2}?api-version=7.0"
                 $repoUri = $repoUriTemplate -f $Organization, $projectId, $repoId
 
-                $repoInfo = Invoke-RestMethod -Uri $repoUri -Headers $AdoAuthenticationHeader -Method Get
+                $repoInfo = Invoke-RestMethod -Uri $repoUri -Headers $AdoAuthenticationHeader -Method 'GET'
+
+                # Get Secret Protection Changed By Display Name
+                $secretProtectionChangedByDisplayName = $null
+                if ($currentRepo.secretProtectionFeatures.secretProtectionChangedBy -ne "00000000-0000-0000-0000-000000000000") {
+                    $identityUriTemplate = "https://vssps.dev.azure.com/{0}/_apis/identities/{1}?api-version=7.2-preview.1"
+                    $identityUri = $identityUriTemplate -f $Organization, $currentRepo.secretProtectionFeatures.secretProtectionChangedBy
+
+                    $identityInfo = Invoke-RestMethod -Uri $identityUri -Headers $AdoAuthenticationHeader -Method 'GET'
+                    $secretProtectionChangedByDisplayName = $identityInfo.providerDisplayName
+                }
+
+                # Get Code Security Changed By Display Name
+                $codeSecurityChangedByDisplayName = $null
+                if ($currentRepo.codeSecurityFeatures.codeSecurityChangedBy -ne "00000000-0000-0000-0000-000000000000") {
+                    $identityUriTemplate = "https://vssps.dev.azure.com/{0}/_apis/identities/{1}?api-version=7.2-preview.1"
+                    $identityUri = $identityUriTemplate -f $Organization, $currentRepo.codeSecurityFeatures.codeSecurityChangedBy
+
+                    $identityInfo = Invoke-RestMethod -Uri $identityUri -Headers $AdoAuthenticationHeader -Method 'GET'
+                    $codeSecurityChangedByDisplayName = $identityInfo.providerDisplayName
+                }
 
                 # Add to result collection
                 [System.Void]$repoAdvancedSecurityStatusCollection.Add([PSCustomObject]@{
-                        ProjectId                 = $projectId
-                        ProjectName               = $projectInfo.name
-                        RepositoryId              = $repoId
-                        RepositoryName            = $repoInfo.name
-                        SecretProtectionEnabled   = $true
-                        DependencyScanningEnabled = $false
-                        CodeSecurityEnabled       = $false
+                        ProjectId                = $projectId
+                        ProjectName              = $projectInfo.name
+                        RepositoryId             = $repoId
+                        RepositoryName           = $repoInfo.name
+                        SecretProtectionFeatures = [PSCustomObject]@{
+                            SecretProtectionEnabled                   = $currentRepo.secretProtectionFeatures.secretProtectionEnabled
+                            SecretProtectionEnablementLastChangedDate = $currentRepo.secretProtectionFeatures.secretProtectionEnablementLastChangedDate
+                            SecretProtectionChangedBy                 = $secretProtectionChangedByDisplayName
+                            BlockPushes                               = $currentRepo.secretProtectionFeatures.blockPushes
+                        }
+                        CodeSecurityFeatures     = [PSCustomObject]@{
+                            CodeSecurityEnabled                = $currentRepo.codeSecurityFeatures.codeSecurityEnabled
+                            CodeSecurityLastChangedDate        = $currentRepo.codeSecurityFeatures.codeSecurityLastChangedDate
+                            CodeSecurityChangedBy              = $codeSecurityChangedByDisplayName
+                            DependencyScanningInjectionEnabled = $currentRepo.codeSecurityFeatures.dependencyScanningInjectionEnabled
+                        }
                     })
             }
 
-            [System.Object[]]$codeSecurityEnabledRepos = $restResponse.reposEnablementStatus |
-            Where-Object { $_.codeSecurityFeatures.codeSecurityEnabled -eq $true }
-
-            # Process Code Security enabled repositories
-            foreach ($currentRepo in $codeSecurityEnabledRepos) {
-                $projectId = $currentRepo.projectId
-                $repoId = $currentRepo.repositoryId
-
-                # Check if this repository is already in our results (has secretProtectionEnabledRepos enabled)
-                $existingRepo = $repoAdvancedSecurityStatusCollection | Where-Object { $_.RepositoryId -eq $repoId }
-
-                if ($existingRepo) {
-                    # Update existing entry
-                    $existingRepo.CodeSecurityEnabled = $currentRepo.codeSecurityFeatures.codeSecurityEnabled
-                    $existingRepo.DependencyScanningEnabled = $currentRepo.codeSecurityFeatures.dependencyScanningInjectionEnabled
-
-                } else {
-                    # Get project details
-                    $projectUriTemplate = "https://dev.azure.com/{0}/_apis/projects/{1}?api-version=7.0"
-                    $projectUri = $projectUriTemplate -f $Organization, $projectId
-                    $projectInfo = Invoke-RestMethod -Uri $projectUri -Headers $AdoAuthenticationHeader -Method Get
-
-                    # Get repository details
-                    $repoUriTemplate = "https://dev.azure.com/{0}/{1}/_apis/git/repositories/{2}?api-version=7.0"
-                    $repoUri = $repoUriTemplate -f $Organization, $projectId, $repoId
-                    $repoInfo = Invoke-RestMethod -Uri $repoUri -Headers $AdoAuthenticationHeader -Method Get
-
-                    # Add new entry
-                    [System.Void]$repoAdvancedSecurityStatusCollection.Add([PSCustomObject]@{
-                            ProjectId                 = $projectId
-                            ProjectName               = $projectInfo.name
-                            RepositoryId              = $repoId
-                            RepositoryName            = $repoInfo.name
-                            SecretProtectionEnabled   = $false
-                            CodeSecurityEnabled       = $currentRepo.codeSecurityFeatures.codeSecurityEnabled
-                            DependencyScanningEnabled = $currentRepo.codeSecurityFeatures.dependencyScanningInjectionEnabled
-                        })
-                }
-            }
-
             # Summary output
-            $reposWithSecretProtection = $repoAdvancedSecurityStatusCollection | Where-Object { $_.SecretProtectionEnabled -eq $true }
-            $reposWithCodeSecurity = $repoAdvancedSecurityStatusCollection | Where-Object { $_.CodeSecurityEnabled -eq $true }
-            Write-Information -Message "Total repositories with Secret Protection enabled: [$($reposWithSecretProtection.Count)]"
-            Write-Information -Message "Total repositories with Code Security enabled: [$($reposWithCodeSecurity.Count)]"
+            $reposWithOutSecretProtection = $repoAdvancedSecurityStatusCollection | Where-Object { $_.SecretProtectionFeatures.SecretProtectionEnabled -eq $false }
+            $reposWithOutCodeSecurity = $repoAdvancedSecurityStatusCollection | Where-Object { $_.CodeSecurityFeatures.CodeSecurityEnabled -eq $false }
+            Write-Information -Message "Repositories that have Secret Protection disabled:"
+            Write-Information -Message "[$($reposWithOutSecretProtection.Count) out of $($repoAdvancedSecurityStatusCollection.Count)]"
+
+            Write-Information -Message "Repositories that have Code Security disabled: "
+            Write-Information -Message "[$($reposWithOutCodeSecurity.Count) out of $($repoAdvancedSecurityStatusCollection.Count)]"
 
             # Return the result
             return  $repoAdvancedSecurityStatusCollection
-
-            Write-Host "Stopped here!!!"
         }
     } catch {
         Write-Error "Unexpected error occurred: $($_.Exception.Message)" -ErrorAction Stop

--- a/powershell/functions/Read-AdoRepoAdvancedSecurityStatus.ps1
+++ b/powershell/functions/Read-AdoRepoAdvancedSecurityStatus.ps1
@@ -34,7 +34,7 @@ function Read-AdoRepoAdvancedSecurityStatus {
             Where-Object { $_.secretProtectionFeatures.secretProtectionEnabled -eq $true }
 
             # Initialize result collection
-            $result = [System.Collections.ArrayList]::new()
+            $repoAdvancedSecurityStatusCollection = [System.Collections.ArrayList]::new()
 
             # Process Secret Protection enabled repositories
             foreach ($currentRepo in $secretProtectionEnabledRepos) {
@@ -72,13 +72,13 @@ function Read-AdoRepoAdvancedSecurityStatus {
                 $projectId = $currentRepo.projectId
                 $repoId = $currentRepo.repositoryId
 
-                # Check if this repository is already in our results (has both enabled)
-                $existingRepo = $result | Where-Object { $_.RepositoryId -eq $repoId }
+                # Check if this repository is already in our results (has secretProtectionEnabledRepos enabled)
+                $existingRepo = $repoAdvancedSecurityStatusCollection | Where-Object { $_.RepositoryId -eq $repoId }
 
                 if ($existingRepo) {
                     # Update existing entry
                     $existingRepo.CodeSecurityEnabled = $currentRepo.codeSecurityFeatures.codeSecurityEnabled
-                    $existingRepo.DependencyScanningEnabled = $currentRepo.codeSecurityFeatures.dependencyScanningEnabled
+                    $existingRepo.DependencyScanningEnabled = $currentRepo.codeSecurityFeatures.dependencyScanningInjectionEnabled
 
                 } else {
                     # Get project details
@@ -99,13 +99,13 @@ function Read-AdoRepoAdvancedSecurityStatus {
                             RepositoryName            = $repoInfo.name
                             SecretProtectionEnabled   = $false
                             CodeSecurityEnabled       = $currentRepo.codeSecurityFeatures.codeSecurityEnabled
-                            DependencyScanningEnabled = $currentRepo.codeSecurityFeatures.dependencyScanningEnabled
+                            DependencyScanningEnabled = $currentRepo.codeSecurityFeatures.dependencyScanningInjectionEnabled
                         })
                 }
             }
 
             # Return the result
-            $result
+            return  $repoAdvancedSecurityStatusCollection
 
             Write-Host "Stopped here!!!"
         }

--- a/powershell/functions/Read-AdoRepoAdvancedSecurityStatus.ps1
+++ b/powershell/functions/Read-AdoRepoAdvancedSecurityStatus.ps1
@@ -1,10 +1,10 @@
 <#
 .SYNOPSIS
-    Reads repository-level Advanced Security enablement for all repos in an
+    Reads repository-level Advanced Security status for all repos in an
     Azure DevOps organization.
 
 .DESCRIPTION
-    Queries the Azure DevOps Advanced Security organization enablement endpoint
+    Queries the Azure DevOps Advanced Security organization status endpoint
     to enumerate each repository's Advanced Security features. For every
     repository, returns whether:
       - Secret Protection is enabled and related metadata (last changed date,

--- a/powershell/functions/Read-AdoRepoAdvancedSecurityStatus.ps1
+++ b/powershell/functions/Read-AdoRepoAdvancedSecurityStatus.ps1
@@ -83,6 +83,7 @@
 #>
 function Read-AdoRepoAdvancedSecurityStatus {
     [CmdletBinding()]
+    [OutputType([System.Collections.ArrayList])]
     param (
         [Parameter(Mandatory)]
         [string]$Organization,
@@ -179,11 +180,11 @@ function Read-AdoRepoAdvancedSecurityStatus {
             # Summary output
             $reposWithOutSecretProtection = $repoAdvancedSecurityStatusCollection | Where-Object { $_.SecretProtectionFeatures.SecretProtectionEnabled -eq $false }
             $reposWithOutCodeSecurity = $repoAdvancedSecurityStatusCollection | Where-Object { $_.CodeSecurityFeatures.CodeSecurityEnabled -eq $false }
-            Write-Information -Message "Repositories that have Secret Protection disabled:"
-            Write-Information -Message "[$($reposWithOutSecretProtection.Count) out of $($repoAdvancedSecurityStatusCollection.Count)]"
+            Write-Information -MessageData "Repositories that have Secret Protection disabled:" -InformationAction Continue
+            Write-Information -MessageData "[$($reposWithOutSecretProtection.Count) out of $($repoAdvancedSecurityStatusCollection.Count)]" -InformationAction Continue
 
-            Write-Information -Message "Repositories that have Code Security disabled: "
-            Write-Information -Message "[$($reposWithOutCodeSecurity.Count) out of $($repoAdvancedSecurityStatusCollection.Count)]"
+            Write-Information -MessageData "Repositories that have Code Security disabled: " -InformationAction Continue
+            Write-Information -MessageData "[$($reposWithOutCodeSecurity.Count) out of $($repoAdvancedSecurityStatusCollection.Count)]" -InformationAction Continue
 
             # Return the result
             return  $repoAdvancedSecurityStatusCollection

--- a/powershell/functions/Read-AdoRepoAdvancedSecurityStatus.ps1
+++ b/powershell/functions/Read-AdoRepoAdvancedSecurityStatus.ps1
@@ -180,11 +180,11 @@ function Read-AdoRepoAdvancedSecurityStatus {
             # Summary output
             $reposWithOutSecretProtection = $repoAdvancedSecurityStatusCollection | Where-Object { $_.SecretProtectionFeatures.SecretProtectionEnabled -eq $false }
             $reposWithOutCodeSecurity = $repoAdvancedSecurityStatusCollection | Where-Object { $_.CodeSecurityFeatures.CodeSecurityEnabled -eq $false }
-            Write-Information -MessageData "Repositories that have Secret Protection disabled:" -InformationAction Continue
-            Write-Information -MessageData "[$($reposWithOutSecretProtection.Count) out of $($repoAdvancedSecurityStatusCollection.Count)]" -InformationAction Continue
+            Write-Information -MessageData "Repositories that have Secret Protection disabled:"
+            Write-Information -MessageData "[$($reposWithOutSecretProtection.Count) out of $($repoAdvancedSecurityStatusCollection.Count)]"
 
-            Write-Information -MessageData "Repositories that have Code Security disabled: " -InformationAction Continue
-            Write-Information -MessageData "[$($reposWithOutCodeSecurity.Count) out of $($repoAdvancedSecurityStatusCollection.Count)]" -InformationAction Continue
+            Write-Information -MessageData "Repositories that have Code Security disabled: "
+            Write-Information -MessageData "[$($reposWithOutCodeSecurity.Count) out of $($repoAdvancedSecurityStatusCollection.Count)]"
 
             # Return the result
             return  $repoAdvancedSecurityStatusCollection


### PR DESCRIPTION
## Summary

This pull request introduces a new PowerShell script, `Read-AdoRepoAdvancedSecurityStatus.ps1`, for organization-wide auditing of Advanced Security features in Azure DevOps repositories.

## Motivation

This script is designed to be easily pluggable into compliance, reporting, and drift detection solutions for Azure DevOps. It enables teams to automate the monitoring and enforcement of security standards across all repositories, ensuring organizational policies are consistently applied and making it easier to detect configuration changes or gaps in security coverage.

## Features

- **Comprehensive Security Status:**  
  Enumerates all repositories in an Azure DevOps organization and reports:
  - Secret Protection status and metadata (last changed date, changed by, block pushes)
  - Code Security status and metadata (last changed date, changed by, dependency scanning)
  - Project and repository names for clarity

- **Structured Output:**  
  Returns a collection of objects with detailed security status for each repository, suitable for compliance, reporting, and drift detection automation.

- **Modern API Usage:**  
  Uses the latest Azure DevOps Advanced Security enablement endpoint and resolves user IDs to display names for auditability.

- **Documentation & Usability:**  
  Includes a full comment-based help section with synopsis, description, parameters, outputs, usage example (with splatting), notes, and links.

- **Best Practices:**  
  Follows PowerShell conventions for readability, maintainability, and line length.