### PR TITLE
Script: Add Remove-ManagementGroupStructure to reset Azure management group hierarchy to tenant root

### DIFF
--- a/powershell/functions/Clean-AzureOrganizationPlatformStructure.ps1
+++ b/powershell/functions/Clean-AzureOrganizationPlatformStructure.ps1
@@ -1,0 +1,132 @@
+#Requires -PSEdition Core
+#Requires -Modules Az.Accounts
+#Requires -Modules Az.Resources
+#Requires -Modules Az.ResourceGraphs
+
+<#
+    .SYNOPSIS
+    Resets the tenant management group configuration toward a root-only baseline.
+
+    .DESCRIPTION
+    This script performs three clean-up actions for Azure management groups:
+    - Sets the default management group to the tenant root management group.
+    - Moves subscriptions to the tenant root management group when needed.
+    - Attempts to remove non-root management groups in repeated passes.
+
+    The script uses Az Graph queries and management group operations at tenant
+    scope. It writes progress and errors to the host output stream.
+
+    .PARAMETER TenantRootManagementGroupId
+    The tenant root management group ID used as the anchor for reset operations.
+
+    .EXAMPLE
+    $parameters = @{
+        TenantRootManagementGroupId = 'contoso-root'
+    }
+    Clean-AzureOrganizationPlatformStructure @parameters
+
+    Sets the default management group to contoso-root, moves subscriptions under
+    it, and removes non-root management groups where possible.
+
+    .NOTES
+    Run this script only when you intentionally want to flatten management group
+    structure and re-parent subscriptions to tenant root.
+
+    Requires permissions to read subscriptions, update management group
+    settings, move subscriptions, and delete management groups.
+
+.NOTES
+    Version     : 1.0.0
+    Author      : Jev - @devjevnl | https://www.devjev.nl
+    Source      : https://github.com/thecloudexplorers/simply-scripted
+#>
+
+[CmdletBinding()]
+param (
+    [Parameter(Mandatory)]
+    [ValidateNotNullOrEmpty()]
+    [System.String] $TenantRootManagementGroupId
+)
+
+#region - Reset the default management group to root
+$managementGroupsProviderUri = "https://management.azure.com/providers/Microsoft.Management/managementGroups/$TenantRootManagementGroupId/settings/default?api-version=2020-05-01"
+
+# creating authentication header
+$token = (Get-AzAccessToken).Token
+$headers = @{
+    Authorization  = "Bearer $token"
+    'Content-Type' = 'application/json'
+}
+
+# creating the request body
+$requestBody = '{
+     "properties": {
+          "defaultManagementGroup": "/providers/Microsoft.Management/managementGroups/' + $TenantRootManagementGroupId + '",
+          "requireAuthorizationForGroupCreation": true
+     }
+}'
+
+$defaultMgResponse = Invoke-RestMethod -Method Get -Uri $managementGroupsProviderUri -Headers $headers
+
+if ($defaultMgResponse.properties.defaultManagementGroup -ne $TenantRootManagementGroupId) {
+    Write-Host "Default management group is [$($defaultMgResponse.properties.defaultManagementGroup)] resetting to root management group"
+    Invoke-RestMethod -Method 'PUT' -Uri $managementGroupsProviderUri -Headers $headers -Body $requestBody
+} else {
+    Write-Host "Default management group is already set to tenant root management group"
+}
+#endregion
+
+#region - moving the existing subscriptions to the tenant management group root
+Write-Host "Moving all subscriptions to Tenant Root Management group"
+$listSubscriptionsQuery = 'resourcecontainers | where type == "microsoft.resources/subscriptions"'
+$graphResultSubscriptions = Search-AzGraph -Query $listSubscriptionsQuery
+
+$graphResultSubscriptions.ForEach{
+    $currentSub = $_
+
+    if ($currentSub.properties.managementGroupAncestorsChain.Count -gt 1 -or $currentSub.properties.managementGroupAncestorsChain.name -ne $TenantRootManagementGroupId) {
+        Write-Host " Moving subscription [$($currentSub.name)] under Tenant Root Management group"
+        New-AzManagementGroupSubscription -GroupName $TenantRootManagementGroupId -SubscriptionId $currentSub.subscriptionId 3>&1 > $null
+        Write-Host "  subscription moved"
+    } else {
+        Write-Host " Skipping, subscription [$($currentSub.name)] is already under the Tenant Root Management group"
+    }
+}
+
+Write-Host "Moving of subscriptions has been completed`n"
+#endregion
+
+
+#region - removing all management groups
+$listManagementGroups = @'
+resourcecontainers
+| where type =~ 'microsoft.management/managementgroups'
+| project name, properties.displayName
+| order by ['name'] desc
+'@
+
+$graphResultManagementGroups = Search-AzGraph -Query $listManagementGroups -UseTenantScope
+$allManagementGroups = $graphResultManagementGroups | Where-Object { $_.name -ne $TenantRootManagementGroupId }
+
+# delete all management groups until no remain
+while ($allManagementGroups.Count -gt 1) {
+
+    $allManagementGroups.ForEach{
+        $currentMg = $_
+        try {
+            Write-Host "Removing management group [$($currentMg.name)]"
+            Remove-AzManagementGroup -GroupName $currentMg.name 3>&1 > $null
+            Write-Host " group removed"
+        } catch {
+            # swallow the exception
+            Write-Host "Failed removing [$($currentMg.name)]."
+        }
+    }
+
+    # get any remaining management groups that could not be deleted due to inheritance
+    $graphResultManagementGroups = Search-AzGraph -Query $listManagementGroups -UseTenantScope
+    $allManagementGroups = $graphResultManagementGroups | Where-Object { $_.name -ne $TenantRootManagementGroupId }
+}
+#endregion
+
+Write-Host "All done!!"

--- a/powershell/functions/Remove-ManagementGroupStructure.ps1
+++ b/powershell/functions/Remove-ManagementGroupStructure.ps1
@@ -36,98 +36,100 @@
     Requires permissions to read subscriptions, update management group
     settings, move subscriptions, and delete management groups.
 
-.NOTES
+    .NOTES
     Version     : 1.0.0
     Author      : Jev - @devjevnl | https://www.devjev.nl
     Source      : https://github.com/thecloudexplorers/simply-scripted
 #>
 
-[CmdletBinding()]
-param (
-    [Parameter(Mandatory)]
-    [ValidateNotNullOrEmpty()]
-    [System.String] $TenantRootManagementGroupId
-)
+function Remove-ManagementGroupStructure {
+    [CmdletBinding()]
+    param (
+        [Parameter(Mandatory)]
+        [ValidateNotNullOrEmpty()]
+        [System.String] $TenantRootManagementGroupId
+    )
 
-#region - Reset the default management group to root
-$managementGroupsProviderUri = "https://management.azure.com/providers/Microsoft.Management/managementGroups/$TenantRootManagementGroupId/settings/default?api-version=2020-05-01"
+    #region - Reset the default management group to root
+    $managementGroupsProviderUri = "https://management.azure.com/providers/Microsoft.Management/managementGroups/$TenantRootManagementGroupId/settings/default?api-version=2020-05-01"
 
-# creating authentication header
-$token = (Get-AzAccessToken).Token
-$headers = @{
-    Authorization  = "Bearer $token"
-    'Content-Type' = 'application/json'
-}
+    # creating authentication header
+    $token = (Get-AzAccessToken).Token
+    $headers = @{
+        Authorization  = "Bearer $token"
+        'Content-Type' = 'application/json'
+    }
 
-# creating the request body
-$requestBody = '{
+    # creating the request body
+    $requestBody = '{
      "properties": {
           "defaultManagementGroup": "/providers/Microsoft.Management/managementGroups/' + $TenantRootManagementGroupId + '",
           "requireAuthorizationForGroupCreation": true
      }
 }'
 
-$defaultMgResponse = Invoke-RestMethod -Method Get -Uri $managementGroupsProviderUri -Headers $headers
+    $defaultMgResponse = Invoke-RestMethod -Method Get -Uri $managementGroupsProviderUri -Headers $headers
 
-if ($defaultMgResponse.properties.defaultManagementGroup -ne $TenantRootManagementGroupId) {
-    Write-Host "Default management group is [$($defaultMgResponse.properties.defaultManagementGroup)] resetting to root management group"
-    Invoke-RestMethod -Method 'PUT' -Uri $managementGroupsProviderUri -Headers $headers -Body $requestBody
-} else {
-    Write-Host "Default management group is already set to tenant root management group"
-}
-#endregion
-
-#region - moving the existing subscriptions to the tenant management group root
-Write-Host "Moving all subscriptions to Tenant Root Management group"
-$listSubscriptionsQuery = 'resourcecontainers | where type == "microsoft.resources/subscriptions"'
-$graphResultSubscriptions = Search-AzGraph -Query $listSubscriptionsQuery
-
-$graphResultSubscriptions.ForEach{
-    $currentSub = $_
-
-    if ($currentSub.properties.managementGroupAncestorsChain.Count -gt 1 -or $currentSub.properties.managementGroupAncestorsChain.name -ne $TenantRootManagementGroupId) {
-        Write-Host " Moving subscription [$($currentSub.name)] under Tenant Root Management group"
-        New-AzManagementGroupSubscription -GroupName $TenantRootManagementGroupId -SubscriptionId $currentSub.subscriptionId 3>&1 > $null
-        Write-Host "  subscription moved"
+    if ($defaultMgResponse.properties.defaultManagementGroup -ne $TenantRootManagementGroupId) {
+        Write-Host "Default management group is [$($defaultMgResponse.properties.defaultManagementGroup)] resetting to root management group"
+        Invoke-RestMethod -Method 'PUT' -Uri $managementGroupsProviderUri -Headers $headers -Body $requestBody
     } else {
-        Write-Host " Skipping, subscription [$($currentSub.name)] is already under the Tenant Root Management group"
+        Write-Host "Default management group is already set to tenant root management group"
     }
-}
+    #endregion
 
-Write-Host "Moving of subscriptions has been completed`n"
-#endregion
+    #region - moving the existing subscriptions to the tenant management group root
+    Write-Host "Moving all subscriptions to Tenant Root Management group"
+    $listSubscriptionsQuery = 'resourcecontainers | where type == "microsoft.resources/subscriptions"'
+    $graphResultSubscriptions = Search-AzGraph -Query $listSubscriptionsQuery
+
+    $graphResultSubscriptions.ForEach{
+        $currentSub = $_
+
+        if ($currentSub.properties.managementGroupAncestorsChain.Count -gt 1 -or $currentSub.properties.managementGroupAncestorsChain.name -ne $TenantRootManagementGroupId) {
+            Write-Host " Moving subscription [$($currentSub.name)] under Tenant Root Management group"
+            New-AzManagementGroupSubscription -GroupName $TenantRootManagementGroupId -SubscriptionId $currentSub.subscriptionId 3>&1 > $null
+            Write-Host "  subscription moved"
+        } else {
+            Write-Host " Skipping, subscription [$($currentSub.name)] is already under the Tenant Root Management group"
+        }
+    }
+
+    Write-Host "Moving of subscriptions has been completed`n"
+    #endregion
 
 
-#region - removing all management groups
-$listManagementGroups = @'
+    #region - removing all management groups
+    $listManagementGroups = @'
 resourcecontainers
 | where type =~ 'microsoft.management/managementgroups'
 | project name, properties.displayName
 | order by ['name'] desc
 '@
 
-$graphResultManagementGroups = Search-AzGraph -Query $listManagementGroups -UseTenantScope
-$allManagementGroups = $graphResultManagementGroups | Where-Object { $_.name -ne $TenantRootManagementGroupId }
-
-# delete all management groups until no remain
-while ($allManagementGroups.Count -gt 1) {
-
-    $allManagementGroups.ForEach{
-        $currentMg = $_
-        try {
-            Write-Host "Removing management group [$($currentMg.name)]"
-            Remove-AzManagementGroup -GroupName $currentMg.name 3>&1 > $null
-            Write-Host " group removed"
-        } catch {
-            # swallow the exception
-            Write-Host "Failed removing [$($currentMg.name)]."
-        }
-    }
-
-    # get any remaining management groups that could not be deleted due to inheritance
     $graphResultManagementGroups = Search-AzGraph -Query $listManagementGroups -UseTenantScope
     $allManagementGroups = $graphResultManagementGroups | Where-Object { $_.name -ne $TenantRootManagementGroupId }
-}
-#endregion
 
-Write-Host "All done!!"
+    # delete all management groups until no remain
+    while ($allManagementGroups.Count -gt 1) {
+
+        $allManagementGroups.ForEach{
+            $currentMg = $_
+            try {
+                Write-Host "Removing management group [$($currentMg.name)]"
+                Remove-AzManagementGroup -GroupName $currentMg.name 3>&1 > $null
+                Write-Host " group removed"
+            } catch {
+                # swallow the exception
+                Write-Host "Failed removing [$($currentMg.name)]."
+            }
+        }
+
+        # get any remaining management groups that could not be deleted due to inheritance
+        $graphResultManagementGroups = Search-AzGraph -Query $listManagementGroups -UseTenantScope
+        $allManagementGroups = $graphResultManagementGroups | Where-Object { $_.name -ne $TenantRootManagementGroupId }
+    }
+    #endregion
+
+    Write-Host "All done!!"
+}

--- a/powershell/functions/Remove-ManagementGroupStructure.ps1
+++ b/powershell/functions/Remove-ManagementGroupStructure.ps1
@@ -1,7 +1,7 @@
 #Requires -PSEdition Core
 #Requires -Modules Az.Accounts
 #Requires -Modules Az.Resources
-#Requires -Modules Az.ResourceGraphs
+#Requires -Modules Az.ResourceGraph
 
 <#
     .SYNOPSIS
@@ -51,12 +51,16 @@ function Remove-ManagementGroupStructure {
     )
 
     #region - Reset the default management group to root
-    $managementGroupsProviderUri = "https://management.azure.com/providers/Microsoft.Management/managementGroups/$TenantRootManagementGroupId/settings/default?api-version=2020-05-01"
+    $managementGroupsProviderUri = "https://management.azure.com/providers/Microsoft.Management/" +
+    "managementGroups/$TenantRootManagementGroupId/" +
+    "settings/default?api-version=2020-05-01"
 
-    # creating authentication header
-    $token = (Get-AzAccessToken).Token
+    # Creating authentication header by getting the current token and decoding it to be used in the REST API call
+    $currentToken = Get-AzAccessToken
+    $token = $currentToken.Token | ConvertFrom-SecureString -AsPlainText
+    $tokenType = $currentToken.Type
     $headers = @{
-        Authorization  = "Bearer $token"
+        Authorization  = "$tokenType $token"
         'Content-Type' = 'application/json'
     }
 
@@ -81,7 +85,8 @@ function Remove-ManagementGroupStructure {
     #region - moving the existing subscriptions to the tenant management group root
     Write-Host "Moving all subscriptions to Tenant Root Management group"
     $listSubscriptionsQuery = 'resourcecontainers | where type == "microsoft.resources/subscriptions"'
-    $graphResultSubscriptions = Search-AzGraph -Query $listSubscriptionsQuery
+    $graphResultSubscriptions = Search-AzGraph -Query $listSubscriptionsQuery -UseTenantScope
+    Write-Host "Identified [$($graphResultSubscriptions.Count)] subscriptions in the tenant'"
 
     $graphResultSubscriptions.ForEach{
         $currentSub = $_
@@ -122,6 +127,7 @@ resourcecontainers
             } catch {
                 # swallow the exception
                 Write-Host "Failed removing [$($currentMg.name)]."
+                Write-Warning -Message "$($_.Exception.Message)"
             }
         }
 

--- a/powershell/functions/Remove-ManagementGroupStructure.ps1
+++ b/powershell/functions/Remove-ManagementGroupStructure.ps1
@@ -5,7 +5,8 @@
 
 <#
     .SYNOPSIS
-    Resets the tenant management group configuration toward a root-only baseline.
+    Resets the tenant management group configuration toward a root-only
+    baseline.
 
     .DESCRIPTION
     This script performs three clean-up actions for Azure management groups:
@@ -23,7 +24,7 @@
     $parameters = @{
         TenantRootManagementGroupId = 'contoso-root'
     }
-    Clean-AzureOrganizationPlatformStructure @parameters
+    Remove-ManagementGroupStructure @parameters
 
     Sets the default management group to contoso-root, moves subscriptions under
     it, and removes non-root management groups where possible.

--- a/powershell/functions/Remove-ManagementGroupStructure.ps1
+++ b/powershell/functions/Remove-ManagementGroupStructure.ps1
@@ -43,7 +43,7 @@
 #>
 
 function Remove-ManagementGroupStructure {
-    [CmdletBinding()]
+    [CmdletBinding(SupportsShouldProcess)]
     param (
         [Parameter(Mandatory)]
         [ValidateNotNullOrEmpty()]
@@ -76,7 +76,9 @@ function Remove-ManagementGroupStructure {
 
     if ($defaultMgResponse.properties.defaultManagementGroup -ne $TenantRootManagementGroupId) {
         Write-Host "Default management group is [$($defaultMgResponse.properties.defaultManagementGroup)] resetting to root management group"
-        Invoke-RestMethod -Method 'PUT' -Uri $managementGroupsProviderUri -Headers $headers -Body $requestBody
+        if ($PSCmdlet.ShouldProcess($TenantRootManagementGroupId, 'Set default management group')) {
+            Invoke-RestMethod -Method 'PUT' -Uri $managementGroupsProviderUri -Headers $headers -Body $requestBody
+        }
     } else {
         Write-Host "Default management group is already set to tenant root management group"
     }
@@ -86,21 +88,23 @@ function Remove-ManagementGroupStructure {
     Write-Host "Moving all subscriptions to Tenant Root Management group"
     $listSubscriptionsQuery = 'resourcecontainers | where type == "microsoft.resources/subscriptions"'
     $graphResultSubscriptions = Search-AzGraph -Query $listSubscriptionsQuery -UseTenantScope
-    Write-Host "Identified [$($graphResultSubscriptions.Count)] subscriptions in the tenant'"
+    Write-Host "Identified [$($graphResultSubscriptions.Count)] subscriptions in the tenant'" -ForegroundColor Cyan
 
     $graphResultSubscriptions.ForEach{
         $currentSub = $_
 
         if ($currentSub.properties.managementGroupAncestorsChain.Count -gt 1 -or $currentSub.properties.managementGroupAncestorsChain.name -ne $TenantRootManagementGroupId) {
-            Write-Host " Moving subscription [$($currentSub.name)] under Tenant Root Management group"
-            New-AzManagementGroupSubscription -GroupName $TenantRootManagementGroupId -SubscriptionId $currentSub.subscriptionId 3>&1 > $null
-            Write-Host "  subscription moved"
+            Write-Host " Moving subscription [$($currentSub.name)] under Tenant Root Management group" -ForegroundColor Cyan
+            if ($PSCmdlet.ShouldProcess($currentSub.name, 'Move subscription to tenant root management group')) {
+                New-AzManagementGroupSubscription -GroupName $TenantRootManagementGroupId -SubscriptionId $currentSub.subscriptionId 3>&1 > $null
+                Write-Host "  subscription moved" -ForegroundColor Green
+            }
         } else {
-            Write-Host " Skipping, subscription [$($currentSub.name)] is already under the Tenant Root Management group"
+            Write-Host " Skipping, subscription [$($currentSub.name)] is already under the Tenant Root Management group" -ForegroundColor Yellow
         }
     }
 
-    Write-Host "Moving of subscriptions has been completed`n"
+    Write-Host "Moving of subscriptions has been completed`n" -ForegroundColor Green
     #endregion
 
 
@@ -121,15 +125,21 @@ resourcecontainers
         $allManagementGroups.ForEach{
             $currentMg = $_
             try {
-                Write-Host "Removing management group [$($currentMg.name)]"
-                Remove-AzManagementGroup -GroupName $currentMg.name 3>&1 > $null
-                Write-Host " group removed"
+                Write-Host "Removing management group [$($currentMg.name)]" -ForegroundColor Cyan
+                if ($PSCmdlet.ShouldProcess($currentMg.name, 'Remove management group')) {
+                    Remove-AzManagementGroup -GroupName $currentMg.name 3>&1 > $null
+                    Write-Host " group removed" -ForegroundColor Green
+                }
             } catch {
                 # swallow the exception
-                Write-Host "Failed removing [$($currentMg.name)]."
+                Write-Host "Failed removing [$($currentMg.name)]." -ForegroundColor Yellow
                 Write-Warning -Message "$($_.Exception.Message)"
             }
         }
+
+        # If WhatIf is active, resources are never deleted so the loop would never
+        # terminate; break after a single simulated pass instead.
+        if ($WhatIfPreference) { break }
 
         # get any remaining management groups that could not be deleted due to inheritance
         $graphResultManagementGroups = Search-AzGraph -Query $listManagementGroups -UseTenantScope
@@ -137,5 +147,5 @@ resourcecontainers
     }
     #endregion
 
-    Write-Host "All done!!"
+    Write-Host "All done!!" -ForegroundColor Green
 }


### PR DESCRIPTION
### Summary
This PR introduces Remove-ManagementGroupStructure, a new PowerShell function that resets tenant management group configuration toward a root-only baseline.

### What this adds
- Adds a new function: Remove-ManagementGroupStructure
- Sets the default management group to the tenant root management group
- Moves subscriptions to tenant root when they are not already attached there
- Iteratively removes non-root management groups as parent/child constraints are resolved

### Why
This adds new tenant-level cleanup functionality to quickly normalize or rebuild management group structure in a consistent and repeatable way. The focus of this script is to assist development process of management group related functionality and to clean canary like environments to test greefield deployments.

### Notes
- This function is intentionally tenant-impacting and should be used with care.
- Required permissions include:
  - Updating management group settings
  - Moving subscriptions between management groups
  - Deleting management groups