### PR TITLE
Script: Add Remove-AllEnIdAppRegistrations to bulk-remove Entra ID app registrations with exclusion support

### DIFF
--- a/powershell/functions/Remove-AllEnIdAppRegistrations.ps1
+++ b/powershell/functions/Remove-AllEnIdAppRegistrations.ps1
@@ -39,7 +39,6 @@
 #>
 function Remove-AzADAppRegistration {
     [CmdletBinding(SupportsShouldProcess)]
-    [Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSReviewUnusedParameter', 'ExcludeFilter', Justification = 'False positive for $ExcludeFilter')]
     param (
         [Parameter(Mandatory)]
         [Microsoft.Azure.Commands.Profile.Models.PSAzureTenant]$Tenant,

--- a/powershell/functions/Remove-AllEnIdAppRegistrations.ps1
+++ b/powershell/functions/Remove-AllEnIdAppRegistrations.ps1
@@ -1,0 +1,74 @@
+#Requires -PSEdition Core
+#Requires -Modules Az.Resources
+<#
+    .SYNOPSIS
+    Removes Entra ID app registrations in a tenant, excluding specified app IDs.
+
+    .DESCRIPTION
+    Remove-AzADAppRegistration queries applications in Microsoft Graph for the
+    provided tenant and removes app registrations that are not part of the
+    ExcludeFilter list.
+
+    The function supports ShouldProcess, so you can run with -WhatIf and
+    -Confirm for safe execution.
+
+    .PARAMETER Tenant
+    Tenant context to target for app registration cleanup.
+
+    .PARAMETER ExcludeFilter
+    Optional array of application object IDs to exclude from removal.
+
+    .EXAMPLE
+    $parameters = @{
+        Tenant        = (Get-AzContext).Tenant
+        ExcludeFilter = @("AppId1", "AppId2")
+        WhatIf        = $true
+    }
+    Remove-AzADAppRegistration @parameters
+
+    Shows which app registrations would be removed without making changes.
+
+    .NOTES
+    Requires an authenticated Microsoft Graph context for Get-MgApplication and
+    the required permissions to remove applications.
+
+    Version     : 1.0.0
+    Author      : Jev - @devjevnl | https://www.devjev.nl
+    Source      : https://github.com/thecloudexplorers/simply-scripted
+
+#>
+function Remove-AzADAppRegistration {
+    [CmdletBinding(SupportsShouldProcess)]
+    [Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSReviewUnusedParameter', 'ExcludeFilter', Justification = 'False positive for $ExcludeFilter')]
+    param (
+        [Parameter(Mandatory = $true)]
+        [Microsoft.Azure.Commands.Profile.Models.PSAzureTenant]$Tenant,
+
+        [String[]]$ExcludeFilter
+    )
+
+    Write-Host "Start cleaning App registration in Tenant: [$($Tenant.Id)]"
+
+    # prepare OData filter expression to pass it to Get-MgApplication -Filter parameter to make filter in one call
+    # https://learn.microsoft.com/en-us/graph/filter-query-parameter?tabs=http
+    $filter = "NOT(id in ($($ExcludeFilter | Join-String -SingleQuote -Separator ',')))"
+
+    # use Advanced query parameters to return filtered applications
+    # https://learn.microsoft.com/en-us/graph/aad-advanced-queries?tabs=http
+    $appsToRemoveFiltered = Get-MgApplication -Filter $filter -ConsistencyLevel eventual -CountVariable 1
+
+    # iterate through the filtered list of AAD Apps registered and remove each App
+    foreach ($app in $appsToRemoveFiltered) {
+        Write-Host "Removing AppRegistration: $($app.DisplayName)"
+        try {
+            if ($PSCmdlet.ShouldProcess( $app, "Remove-AzADAppRegistration")) {
+                $app | Remove-AzADApplication
+            } else {
+                $app | Remove-AzADApplication -WhatIf
+            }
+        } catch {
+            Write-Warning -Message "An error occurred while removing Azure AD App: [$($_.Exception.Message)]"
+        }
+    }
+    Write-Host "Removed $($appsToRemoveFiltered.Count) AAD Apps registered."
+}

--- a/powershell/functions/Remove-AllEnIdAppRegistrations.ps1
+++ b/powershell/functions/Remove-AllEnIdAppRegistrations.ps1
@@ -41,7 +41,7 @@ function Remove-AzADAppRegistration {
     [CmdletBinding(SupportsShouldProcess)]
     [Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSReviewUnusedParameter', 'ExcludeFilter', Justification = 'False positive for $ExcludeFilter')]
     param (
-        [Parameter(Mandatory = $true)]
+        [Parameter(Mandatory)]
         [Microsoft.Azure.Commands.Profile.Models.PSAzureTenant]$Tenant,
 
         [String[]]$ExcludeFilter

--- a/powershell/functions/Remove-AllEnIdAppRegistrations.ps1
+++ b/powershell/functions/Remove-AllEnIdAppRegistrations.ps1
@@ -12,15 +12,11 @@
     The function supports ShouldProcess, so you can run with -WhatIf and
     -Confirm for safe execution.
 
-    .PARAMETER Tenant
-    Tenant context to target for app registration cleanup.
-
     .PARAMETER ExcludeFilter
     Optional array of application object IDs to exclude from removal.
 
     .EXAMPLE
     $parameters = @{
-        Tenant        = (Get-AzContext).Tenant
         ExcludeFilter = @("AppId1", "AppId2")
         WhatIf        = $true
     }
@@ -40,34 +36,31 @@
 function Remove-AzADAppRegistration {
     [CmdletBinding(SupportsShouldProcess)]
     param (
-        [Parameter(Mandatory)]
-        [Microsoft.Azure.Commands.Profile.Models.PSAzureTenant]$Tenant,
-
-        [String[]]$ExcludeFilter
+        [ValidateNotNullOrEmpty()]
+        [String[]] $ExcludeFilter
     )
 
-    Write-Host "Start cleaning App registration in Tenant: [$($Tenant.Id)]"
+    Write-Host "Start cleaning App registrations"
 
-    # prepare OData filter expression to pass it to Get-MgApplication -Filter parameter to make filter in one call
+    # Prepare OData filter expression to pass it to Get-MgApplication -Filter parameter to make filter in one call
     # https://learn.microsoft.com/en-us/graph/filter-query-parameter?tabs=http
     $filter = "NOT(id in ($($ExcludeFilter | Join-String -SingleQuote -Separator ',')))"
 
-    # use Advanced query parameters to return filtered applications
+    # Use Advanced query parameters to return filtered applications
     # https://learn.microsoft.com/en-us/graph/aad-advanced-queries?tabs=http
     $appsToRemoveFiltered = Get-MgApplication -Filter $filter -ConsistencyLevel eventual -CountVariable 1
 
-    # iterate through the filtered list of AAD Apps registered and remove each App
+    # Iterate through the filtered list of AAD Apps registered and remove each App
     foreach ($app in $appsToRemoveFiltered) {
-        Write-Host "Removing AppRegistration: $($app.DisplayName)"
+        Write-Host "Removing AppRegistration: $($app.DisplayName)" -ForegroundColor Cyan
         try {
+            # Support -WhatIf and -Confirm parameters for safe execution
             if ($PSCmdlet.ShouldProcess( $app, "Remove-AzADAppRegistration")) {
                 $app | Remove-AzADApplication
-            } else {
-                $app | Remove-AzADApplication -WhatIf
             }
         } catch {
-            Write-Warning -Message "An error occurred while removing Azure AD App: [$($_.Exception.Message)]"
+            Write-Host "An error occurred while removing Azure AD App: [$($_.Exception.Message)]" -ForegroundColor Red -ErrorAction Continue
         }
     }
-    Write-Host "Removed $($appsToRemoveFiltered.Count) AAD Apps registered."
+    Write-Host "Removed $($appsToRemoveFiltered.Count) AAD Apps registered." -ForegroundColor Green
 }

--- a/powershell/functions/Remove-AllEnIdAppRegistrations.ps1
+++ b/powershell/functions/Remove-AllEnIdAppRegistrations.ps1
@@ -40,10 +40,10 @@ function Remove-AllEnIdAppRegistrations {
         [System.String[]] $ExcludeFilter
     )
 
-    Write-Host "Start cleaning App registrations"
+    Write-Host "Start cleaning App registrations" -ForegroundColor Cyan
 
     $currentToken = Get-AzAccessToken -ResourceUrl "https://graph.microsoft.com/"
-    Connect-MgGraph -AccessToken $currentToken.Token
+    Connect-MgGraph -AccessToken $currentToken.Token -NoWelcome
 
     # Retrieve all app registrations and exclude those matching ExcludeFilter display names
     # https://learn.microsoft.com/en-us/graph/aad-advanced-queries?tabs=http
@@ -54,7 +54,7 @@ function Remove-AllEnIdAppRegistrations {
         Write-Host "Removing AppRegistration [$($app.DisplayName)]" -ForegroundColor Cyan
         try {
             # Support -WhatIf and -Confirm parameters for safe execution
-            if ($PSCmdlet.ShouldProcess( $app.DisplayName, "Remove-AllEnIdAppRegistrations")) {
+            if ($PSCmdlet.ShouldProcess($app.DisplayName, "Remove-AllEnIdAppRegistrations")) {
                 $app | Remove-AzADApplication
             }
         } catch {

--- a/powershell/functions/Remove-AllEnIdAppRegistrations.ps1
+++ b/powershell/functions/Remove-AllEnIdAppRegistrations.ps1
@@ -5,7 +5,7 @@
     Removes Entra ID app registrations in a tenant, excluding specified app IDs.
 
     .DESCRIPTION
-    Remove-AzADAppRegistration queries applications in Microsoft Graph for the
+    Remove-AllEnIdAppRegistrations queries applications in Microsoft Graph for the
     provided tenant and removes app registrations that are not part of the
     ExcludeFilter list.
 
@@ -20,7 +20,7 @@
         ExcludeFilter = @("AppId1", "AppId2")
         WhatIf        = $true
     }
-    Remove-AzADAppRegistration @parameters
+    Remove-AllEnIdAppRegistrations @parameters
 
     Shows which app registrations would be removed without making changes.
 
@@ -33,34 +33,33 @@
     Source      : https://github.com/thecloudexplorers/simply-scripted
 
 #>
-function Remove-AzADAppRegistration {
+function Remove-AllEnIdAppRegistrations {
     [CmdletBinding(SupportsShouldProcess)]
     param (
         [ValidateNotNullOrEmpty()]
-        [String[]] $ExcludeFilter
+        [System.String[]] $ExcludeFilter
     )
 
     Write-Host "Start cleaning App registrations"
 
-    # Prepare OData filter expression to pass it to Get-MgApplication -Filter parameter to make filter in one call
-    # https://learn.microsoft.com/en-us/graph/filter-query-parameter?tabs=http
-    $filter = "NOT(id in ($($ExcludeFilter | Join-String -SingleQuote -Separator ',')))"
+    $currentToken = Get-AzAccessToken -ResourceUrl "https://graph.microsoft.com/"
+    Connect-MgGraph -AccessToken $currentToken.Token
 
-    # Use Advanced query parameters to return filtered applications
+    # Retrieve all app registrations and exclude those matching ExcludeFilter display names
     # https://learn.microsoft.com/en-us/graph/aad-advanced-queries?tabs=http
-    $appsToRemoveFiltered = Get-MgApplication -Filter $filter -ConsistencyLevel eventual -CountVariable 1
+    $appsToRemoveFiltered = Get-MgApplication -All | Where-Object { $_.DisplayName -notin $ExcludeFilter }
 
-    # Iterate through the filtered list of AAD Apps registered and remove each App
+    # Iterate through the filtered list of Entra ID Apps and remove each App
     foreach ($app in $appsToRemoveFiltered) {
-        Write-Host "Removing AppRegistration: $($app.DisplayName)" -ForegroundColor Cyan
+        Write-Host "Removing AppRegistration [$($app.DisplayName)]" -ForegroundColor Cyan
         try {
             # Support -WhatIf and -Confirm parameters for safe execution
-            if ($PSCmdlet.ShouldProcess( $app, "Remove-AzADAppRegistration")) {
+            if ($PSCmdlet.ShouldProcess( $app.DisplayName, "Remove-AllEnIdAppRegistrations")) {
                 $app | Remove-AzADApplication
             }
         } catch {
-            Write-Host "An error occurred while removing Azure AD App: [$($_.Exception.Message)]" -ForegroundColor Red -ErrorAction Continue
+            Write-Host "An error occurred while removing Entra ID App [$($app.DisplayName)]: [$($_.Exception.Message)]" -ForegroundColor Red -ErrorAction Continue
         }
     }
-    Write-Host "Removed $($appsToRemoveFiltered.Count) AAD Apps registered." -ForegroundColor Green
+    Write-Host "Removed $($appsToRemoveFiltered.Count) Entra ID Apps" -ForegroundColor Green
 }


### PR DESCRIPTION
### Summary
This PR introduces Remove-AllEnIdAppRegistrations, a PowerShell function that removes Entra ID app registrations in a target tenant while honoring an exclusion list.

### What this adds
- Adds Remove-AzADAppRegistration with tenant-scoped cleanup behavior
- Supports exclusion-based protection via ExcludeFilter
- Uses Microsoft Graph query filtering to retrieve only candidate applications
- Removes applications with ShouldProcess support for safe execution paths
- Includes try/catch handling with warning output for failed removals

### Why
This adds a repeatable cleanup utility for Entra ID app registration hygiene in non-production or controlled cleanup scenarios, while preserving explicit allow-listed apps. The focus of this script is to assist development process of management group related functionality and to clean canary like environments to test greefield deployments.

### Notes
- This function performs destructive operations and should be used intentionally.
- Required permissions include Graph read of applications and permission to remove app registrations.
- Recommended first run is with WhatIf for impact preview.