### PR TITLE
Script: Add Remove-AllEnIdGroups to bulk-remove Entra ID groups with exclusion filters

### DIFF
--- a/powershell/functions/Remove-AllEnIdGroups.ps1
+++ b/powershell/functions/Remove-AllEnIdGroups.ps1
@@ -39,7 +39,7 @@ function Remove-AllEnIdGroups {
         [System.String[]] $ExcludeFilter
     )
 
-    Write-Host "Start cleaning App registrations"
+    Write-Host "Start cleaning App registrations" -ForegroundColor Cyan
     # Get list of all security groups and exclude one in ExcludeFilter
     [System.Object[]] $groupsToRemove = Get-AzADGroup | Where-Object { $_.DisplayName -notin $ExcludeFilter }
 

--- a/powershell/functions/Remove-AllEnIdGroups.ps1
+++ b/powershell/functions/Remove-AllEnIdGroups.ps1
@@ -41,19 +41,19 @@ function Remove-AllEnIdGroups {
 
     Write-Host "Start cleaning App registrations"
     # Get list of all security groups and exclude one in ExcludeFilter
-    $groupsToRemove = Get-AzADGroup | Where-Object { $_.DisplayName -notin $ExcludeFilter }
+    [System.Object[]] $groupsToRemove = Get-AzADGroup | Where-Object { $_.DisplayName -notin $ExcludeFilter }
 
     # Iterate through the filtered list of security groups and remove each group
     foreach ($group in $groupsToRemove) {
-        Write-Host "Removing group: $($group.DisplayName)" -ForegroundColor Cyan
+        Write-Host "Removing group [$($group.DisplayName)]" -ForegroundColor Cyan
         try {
             # Support -WhatIf and -Confirm parameters for safe execution
-            if ($PSCmdlet.ShouldProcess( $group, "Remove-AzADGroup")) {
+            if ($PSCmdlet.ShouldProcess($group.DisplayName, "Remove-AllEnIdGroups")) {
                 $group | Remove-AzADGroup
             }
         } catch {
             Write-Host "An error occurred while removing Azure AD groups: [$($_.Exception.Message)]" -ForegroundColor Red -ErrorAction Continue
         }
     }
-    Write-Host "Removed $($groupsToRemove.Count) groups." -ForegroundColor Green
+    Write-Host "Removed [$($groupsToRemove.Count)] groups." -ForegroundColor Green
 }

--- a/powershell/functions/Remove-AllEnIdGroups.ps1
+++ b/powershell/functions/Remove-AllEnIdGroups.ps1
@@ -2,24 +2,20 @@
 #Requires -Modules Az.Resources
 <#
     .SYNOPSIS
-    Removes Entra ID groups from a tenant, excluding specified group names.
+    Removes Entra ID groups from the tenant in the current context, excluding specified group names.
 
     .DESCRIPTION
-    Remove-AzADCustomGroup retrieves groups from the provided tenant context,
+    Remove-AzADCustomGroup retrieves groups from the current tenant context,
     excludes groups listed in ExcludeFilter, and removes the remaining groups.
 
     The function supports ShouldProcess, so -WhatIf and -Confirm can be used
     for safe execution.
-
-    .PARAMETER Tenant
-    Tenant context used for group cleanup.
 
     .PARAMETER ExcludeFilter
     Array of group display names that must be excluded from removal.
 
     .EXAMPLE
     $parameters = @{
-        Tenant        = (Get-AzContext).Tenant
         ExcludeFilter = @("Canary Platform", "Test Group")
         WhatIf        = $true
     }
@@ -39,13 +35,11 @@
 function Remove-AzADCustomGroup {
     [CmdletBinding(SupportsShouldProcess)]
     param (
-        [Parameter(Mandatory)]
-        [Microsoft.Azure.Commands.Profile.Models.PSAzureTenant]$Tenant,
-
-        [Parameter(Mandatory)]
-        [System.String[]]$ExcludeFilter
+        [ValidateNotNullOrEmpty()]
+        [System.String[]] $ExcludeFilter
     )
 
+    Write-Host "Start cleaning App registrations"
     # Get list of all security groups and exclude one in ExcludeFilter
     $groupsToRemove = Get-AzADGroup | Where-Object { $_.DisplayName -notin $ExcludeFilter }
 
@@ -53,13 +47,12 @@ function Remove-AzADCustomGroup {
     foreach ($group in $groupsToRemove) {
         Write-Host "Removing group: $($group.DisplayName)" -ForegroundColor Cyan
         try {
+            # Support -WhatIf and -Confirm parameters for safe execution
             if ($PSCmdlet.ShouldProcess( $group, "Remove-AzADGroup")) {
                 $group | Remove-AzADGroup
-            } else {
-                $group | Remove-AzADGroup -WhatIf
             }
         } catch {
-            Write-Host "An error occurred while removing Azure AD groups: [$($_.Exception.Message)]" -ForegroundColor Red
+            Write-Host "An error occurred while removing Azure AD groups: [$($_.Exception.Message)]" -ForegroundColor Red -ErrorAction Continue
         }
     }
     Write-Host "Removed $($groupsToRemove.Count) groups." -ForegroundColor Green

--- a/powershell/functions/Remove-AllEnIdGroups.ps1
+++ b/powershell/functions/Remove-AllEnIdGroups.ps1
@@ -5,7 +5,7 @@
     Removes Entra ID groups from the tenant in the current context, excluding specified group names.
 
     .DESCRIPTION
-    Remove-AzADCustomGroup retrieves groups from the current tenant context,
+    Remove-AllEnIdGroups retrieves groups from the current tenant context,
     excludes groups listed in ExcludeFilter, and removes the remaining groups.
 
     The function supports ShouldProcess, so -WhatIf and -Confirm can be used
@@ -19,7 +19,7 @@
         ExcludeFilter = @("Canary Platform", "Test Group")
         WhatIf        = $true
     }
-    Remove-AzADCustomGroup @parameters
+    Remove-AllEnIdGroups @parameters
 
     Shows which groups would be removed without making changes.
 
@@ -32,7 +32,7 @@
     Source      : https://github.com/thecloudexplorers/simply-scripted
 
 #>
-function Remove-AzADCustomGroup {
+function Remove-AllEnIdGroups {
     [CmdletBinding(SupportsShouldProcess)]
     param (
         [ValidateNotNullOrEmpty()]

--- a/powershell/functions/Remove-AllEnIdGroups.ps1
+++ b/powershell/functions/Remove-AllEnIdGroups.ps1
@@ -1,0 +1,66 @@
+#Requires -PSEdition Core
+#Requires -Modules Az.Resources
+<#
+    .SYNOPSIS
+    Removes Entra ID groups from a tenant, excluding specified group names.
+
+    .DESCRIPTION
+    Remove-AzADCustomGroup retrieves groups from the provided tenant context,
+    excludes groups listed in ExcludeFilter, and removes the remaining groups.
+
+    The function supports ShouldProcess, so -WhatIf and -Confirm can be used
+    for safe execution.
+
+    .PARAMETER Tenant
+    Tenant context used for group cleanup.
+
+    .PARAMETER ExcludeFilter
+    Array of group display names that must be excluded from removal.
+
+    .EXAMPLE
+    $parameters = @{
+        Tenant        = (Get-AzContext).Tenant
+        ExcludeFilter = @("Canary Platform", "Test Group")
+        WhatIf        = $true
+    }
+    Remove-AzADCustomGroup @parameters
+
+    Shows which groups would be removed without making changes.
+
+    .NOTES
+    Requires an authenticated Az context with permissions to read and remove
+    Entra ID groups.
+
+    Version     : 1.0.0
+    Author      : Jev - @devjevnl | https://www.devjev.nl
+    Source      : https://github.com/thecloudexplorers/simply-scripted
+
+#>
+function Remove-AzADCustomGroup {
+    [CmdletBinding(SupportsShouldProcess)]
+    param (
+        [Parameter(Mandatory)]
+        [Microsoft.Azure.Commands.Profile.Models.PSAzureTenant]$Tenant,
+
+        [Parameter(Mandatory)]
+        [System.String[]]$ExcludeFilter
+    )
+
+    # Get list of all security groups and exclude one in ExcludeFilter
+    $groupsToRemove = Get-AzADGroup | Where-Object { $_.DisplayName -notin $ExcludeFilter }
+
+    # Iterate through the filtered list of security groups and remove each group
+    foreach ($group in $groupsToRemove) {
+        Write-Host "Removing group: $($group.DisplayName)" -ForegroundColor Cyan
+        try {
+            if ($PSCmdlet.ShouldProcess( $group, "Remove-AzADGroup")) {
+                $group | Remove-AzADGroup
+            } else {
+                $group | Remove-AzADGroup -WhatIf
+            }
+        } catch {
+            Write-Host "An error occurred while removing Azure AD groups: [$($_.Exception.Message)]" -ForegroundColor Red
+        }
+    }
+    Write-Host "Removed $($groupsToRemove.Count) groups." -ForegroundColor Green
+}


### PR DESCRIPTION
### Summary
This PR introduces Remove-AllEnIdGroups, a new PowerShell function that removes Entra ID groups in a target tenant while preserving explicitly excluded group names.

### What this adds
- Adds a new function: Remove-AzADCustomGroup
- Targets tenant-scoped Entra ID group cleanup
- Excludes protected groups via ExcludeFilter
- Removes all remaining groups returned by Get-AzADGroup
- Supports safe execution through ShouldProcess with WhatIf and Confirm
- Includes error handling and progress output during removals

### Why
This adds a reusable cleanup utility for controlled Entra ID tenant reset and test-environment hygiene, while allowing explicit group exclusions to prevent accidental deletion of protected groups.
The focus of this script is to assist development process of management group related functionality and to clean canary like environments to test greefield deployments.

### Notes
- This function performs destructive operations and should be run intentionally.
- Recommended first run is with WhatIf to preview impact before execution.
- Required permissions include reading and removing Entra ID groups.